### PR TITLE
Add engagement model page

### DIFF
--- a/engagement-model.html
+++ b/engagement-model.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>LeftShift AI - Engagement Model</title>
+    <style>
+        :root {
+            --bg-primary: #000000;
+            --bg-secondary: #0a0a0a;
+            --bg-card: #111111;
+            --text-primary: #ffffff;
+            --text-secondary: #888888;
+            --text-muted: #666666;
+            --accent: #4a9eff;
+            --accent-hover: #3a8eef;
+            --border: rgba(255, 255, 255, 0.08);
+            --gradient-1: linear-gradient(90deg, #4a9eff 0%, #00d4ff 100%);
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background-color: var(--bg-primary);
+            color: var(--text-primary);
+            line-height: 1.6;
+        }
+
+        nav {
+            position: fixed;
+            top: 0;
+            width: 100%;
+            background: rgba(0, 0, 0, 0.8);
+            backdrop-filter: blur(20px);
+            -webkit-backdrop-filter: blur(20px);
+            z-index: 1000;
+            padding: 1.25rem 0;
+            border-bottom: 1px solid var(--border);
+        }
+
+        .nav-container {
+            max-width: 1400px;
+            margin: 0 auto;
+            padding: 0 2rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .logo {
+            font-size: 1.75rem;
+            font-weight: 700;
+        }
+
+        .logo-gradient {
+            background: var(--gradient-1);
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+        }
+
+        .nav-links {
+            display: flex;
+            gap: 2.5rem;
+            align-items: center;
+        }
+
+        .nav-links a {
+            color: var(--text-secondary);
+            text-decoration: none;
+            transition: color 0.3s ease;
+            font-size: 0.95rem;
+            font-weight: 500;
+        }
+
+        .nav-links a:hover {
+            color: var(--text-primary);
+        }
+
+        .cta-button {
+            background: var(--accent);
+            color: #ffffff !important;
+            padding: 0.625rem 1.5rem;
+            border-radius: 6px;
+            text-decoration: none;
+            transition: all 0.3s ease;
+            font-weight: 600;
+            font-size: 0.875rem;
+            letter-spacing: 0.02em;
+        }
+
+        main {
+            max-width: 800px;
+            margin: 6rem auto 4rem;
+            padding: 0 1rem;
+        }
+
+        h1 {
+            font-size: 2.5rem;
+            margin-bottom: 1rem;
+        }
+
+        h2 {
+            margin-top: 2.5rem;
+            margin-bottom: 0.75rem;
+            font-size: 1.5rem;
+        }
+
+        p, li {
+            color: var(--text-secondary);
+            margin-bottom: 0.75rem;
+        }
+
+        ul {
+            margin-left: 1.25rem;
+        }
+    </style>
+</head>
+<body>
+    <nav>
+        <div class="nav-container">
+            <div class="logo"><span class="logo-gradient">LeftShift AI</span></div>
+            <div class="nav-links">
+                <a href="index.html#solutions">Solutions</a>
+                <a href="index.html#results">Results</a>
+                <a href="index.html#team">Team</a>
+                <a href="engagement-model.html">Engagement</a>
+                <a href="index.html#contact" class="cta-button">Get Started</a>
+            </div>
+        </div>
+    </nav>
+
+    <main>
+        <h1>Engagement Model</h1>
+        <p>This overview explains how we help engineering organizations adopt AI-driven workflows quickly.</p>
+
+        <h2>Who We Are</h2>
+        <ul>
+            <li>Amit (GM), Ziyad &amp; Hani (Principal Engineers) – led Coupang’s internal “AI-for-Work” program.</li>
+            <li>Shipped enterprise-grade agents, tooling, and adoption playbooks for a 2,500-engineer org.</li>
+            <li>15+ years each building and scaling software at FAANG-class companies.</li>
+        </ul>
+
+        <h2>Why Enterprises Struggle</h2>
+        <ul>
+            <li>Security &amp; Compliance Friction – model access, data isolation, approval loops.</li>
+            <li>Org Complexity – cross-team dependencies, shifting priorities, politics.</li>
+            <li>Signal-to-Noise – thousands of shiny AI demos, few production-ready at scale.</li>
+        </ul>
+        <p>Result: pilot fatigue, stalled roll-outs, and wasted quarters relearning avoidable lessons.</p>
+
+        <h2>Our Ideal Partner</h2>
+        <p>Established tech company (≈500+ engineers) that is:</p>
+        <ul>
+            <li>Eager for AI leverage yet constrained by enterprise realities.</li>
+            <li>Lean enough to move quickly, large enough to feel the pain.</li>
+        </ul>
+
+        <h2>30-Day Outcomes</h2>
+        <ul>
+            <li><strong>Coding &amp; Code Review Automation:</strong> ↑20–40% PRs per engineer; ↓30–40% time-to-merge.</li>
+            <li><strong>Incident Response/SRE Automation:</strong> ↓20–40% Mean-Time-to-Resolve (MTTR).</li>
+            <li><strong>Self-Healing Runbooks &amp; Guardrails:</strong> Fewer on-call pages, faster RCA closure.</li>
+        </ul>
+
+        <h2>Engagement Model</h2>
+        <ol>
+            <li><strong>Discovery &amp; Alignment</strong> – deep-dive on your top friction points.</li>
+            <li><strong>One-Month Pilot</strong> – we embed one day per week, async the rest, and ship working solutions that move a headline metric.</li>
+            <li><strong>Scale-Up</strong> – expand playbooks, toolchains, and change-management patterns once trust is earned.</li>
+        </ol>
+
+        <h2>Operating Rhythm</h2>
+        <ul>
+            <li>Direct Line – Slack/phone with all founders.</li>
+            <li>Hands-On Delivery – we write code, pair with your ICs, and coach exec stakeholders.</li>
+            <li>Transparent Artifacts – weekly demo, KPI dashboard, and next-step backlog.</li>
+        </ul>
+
+        <h2>Proven Playbooks We Bring</h2>
+        <ul>
+            <li>Security review templates for frontier models.</li>
+            <li>OKR patterns to tie AI work to business value.</li>
+            <li>Pre-built agent workflows (LangChain, Devin-style, etc.) ready to customize.</li>
+        </ul>
+
+        <h2>Reference Win (Coupang)</h2>
+        <ul>
+            <li>25-person “AI guild” enabled across 2,500 engineers.</li>
+            <li>40% lift in PR throughput and 30% faster incident recovery within 90 days.</li>
+        </ul>
+
+        <h2>Why Left Shift AI</h2>
+        <ul>
+            <li>Founders Only – no hand-offs to junior consultants.</li>
+            <li>Deep Tech + Change Management – we solve both code and culture.</li>
+            <li>Metric-First Mindset – value demonstrated in the first sprint.</li>
+        </ul>
+
+        <h2>Next Steps</h2>
+        <ol>
+            <li>Identify two high-leverage bottlenecks.</li>
+            <li>Schedule a 60-min scoping call with Amit, Ziyad, and Hani.</li>
+            <li>Kick off the one-month pilot and start measuring impact.</li>
+        </ol>
+        <p>Questions or a use-case in mind? – reach us at <a href="mailto:founders@leftshiftai.com">founders@leftshiftai.com</a>.</p>
+    </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -716,6 +716,7 @@
                 <a href="#solutions">Solutions</a>
                 <a href="#results">Results</a>
                 <a href="#team">Team</a>
+                <a href="engagement-model.html">Engagement</a>
                 <a href="#contact" class="cta-button">Get Started</a>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add a new `engagement-model.html` page describing the consulting process
- link to the page from the main navigation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c6ad5bd6c8332a17d488eebebcb98