### PR TITLE
Make productivity highlight green

### DIFF
--- a/index.html
+++ b/index.html
@@ -1478,7 +1478,7 @@
                     <li><strong>Immediate Impact</strong> – Productivity gains in 30 days vs. 6+ months for hiring</li>
                 </ul>
                 <div style="margin-top: 2rem; padding: 1.5rem; background: rgba(74, 158, 255, 0.05); border: 1px solid rgba(74, 158, 255, 0.2); border-radius: 12px;">
-                    <p style="color: var(--text-primary); font-weight: 600; margin-bottom: 0;">
+                    <p style="color: #4caf50; font-weight: 600; margin-bottom: 0;">
                         Result: 100 engineers with AI tools → 150 effective engineers—only 10% higher spend for 50% more capacity (nonlinear)
                     </p>
                 </div>


### PR DESCRIPTION
## Summary
- highlight the productivity result callout text in green

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f8dd086908332afc1f189e45633aa